### PR TITLE
Add deploy helm generic composite action

### DIFF
--- a/.github/actions/deploy-helm-generic/action.yaml
+++ b/.github/actions/deploy-helm-generic/action.yaml
@@ -1,0 +1,23 @@
+name: Deploy Helm Generic App
+description: Helm upgrade/install generic app chart via OCI
+
+inputs:
+  project:
+    description: Tên thư mục ứng dụng chứa file values.yaml (dưới ./projects)
+    required: true
+  chart:
+    description: Đường dẫn chart OCI (default là ghcr.io/johnhojohn969/generic-app)
+    required: false
+    default: oci://ghcr.io/johnhojohn969/generic-app
+
+runs:
+  using: composite
+  steps:
+    - name: Helm upgrade/install
+      shell: bash
+      run: |
+        helm upgrade --install ${{ inputs.project }} \
+          ${{ inputs.chart }} \
+          -f ./projects/${{ inputs.project }}/values.yaml \
+          --namespace ${{ inputs.project }} \
+          --create-namespace


### PR DESCRIPTION
## Summary
- add composite action to deploy generic Helm chart

## Testing
- `yamllint .github/actions/deploy-helm-generic/action.yaml` *(fails: missing document start, line too long)*

------
https://chatgpt.com/codex/tasks/task_b_687e18e628bc832d888a5aec8d73f74a