### PR TITLE
Fix invalid YAML in build-and-push action

### DIFF
--- a/.github/actions/build-and-push/action.yaml
+++ b/.github/actions/build-and-push/action.yaml
@@ -3,15 +3,15 @@ description: Build and push Docker images for backend and frontend
 
 inputs:
   backend-dir:
-    description: Path to backend Dockerfile (default: ./app)
+    description: "Path to backend Dockerfile (default: ./app)"
     required: false
     default: ./app
   frontend-dir:
-    description: Path to frontend Dockerfile (default: ./frontend)
+    description: "Path to frontend Dockerfile (default: ./frontend)"
     required: false
     default: ./frontend
   tag:
-    description: Image tag to use (default: latest)
+    description: "Image tag to use (default: latest)"
     required: false
     default: latest
 


### PR DESCRIPTION
## Summary
- fix YAML escaping by quoting colon-containing descriptions

## Testing
- `yamllint .github/actions/build-and-push/action.yaml`

------
https://chatgpt.com/codex/tasks/task_b_687f47c0c8f8832d9e33420a57e966b6