### PR TITLE
Fix build-and-push action YAML

### DIFF
--- a/.github/actions/build-and-push/action.yaml
+++ b/.github/actions/build-and-push/action.yaml
@@ -20,7 +20,7 @@ runs:
   steps:
     - name: Log in to GitHub Container Registry
       shell: bash
-      run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      run: echo "${{ github.token }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
     - name: Extract repo name for image prefix
       id: repo


### PR DESCRIPTION
## Summary
- fix reference to the workflow token in build-and-push composite action

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_687f4afdfa64832da270136b48213734