### PR TITLE
Fix uppercase repo names in build-and-push

### DIFF
--- a/.github/actions/build-and-push/action.yaml
+++ b/.github/actions/build-and-push/action.yaml
@@ -25,7 +25,9 @@ runs:
     - name: Extract repo name for image prefix
       id: repo
       shell: bash
-      run: echo "name=$(basename ${{ github.repository }})" >> $GITHUB_OUTPUT
+      run: |
+        repo_name=$(basename "${{ github.repository }}")
+        echo "name=${repo_name,,}" >> "$GITHUB_OUTPUT"
 
     - name: Build & Push Backend
       shell: bash


### PR DESCRIPTION
## Summary
- ensure repo names used in Docker tags are lowercase

## Testing
- `yamllint -s .github/actions/build-and-push/action.yaml`


------
https://chatgpt.com/codex/tasks/task_b_687f4c460738832dacd635ea593ae7a6