### PR TITLE
Improve build-and-deploy flexibility

### DIFF
--- a/.github/actions/build-and-deploy/action.yaml
+++ b/.github/actions/build-and-deploy/action.yaml
@@ -8,6 +8,14 @@ inputs:
     description: "Optional suffix appended to the ephemeral folder name"
     required: false
     default: ''
+  backend-dir:
+    description: "Path to backend Dockerfile"
+    required: false
+    default: ./app
+  frontend-dir:
+    description: "Path to frontend Dockerfile"
+    required: false
+    default: ./frontend
 runs:
   using: composite
   steps:
@@ -17,6 +25,9 @@ runs:
         suffix: ${{ inputs.suffix }}
     - name: Build and Push Images
       uses: johnhojohn969/setup-ephemeral-action/.github/actions/build-and-push@main
+      with:
+        backend-dir: ${{ inputs.backend-dir }}
+        frontend-dir: ${{ inputs.frontend-dir }}
     - name: Determine project name
       id: vars
       shell: bash

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -12,6 +12,14 @@ on:
         description: "Optional suffix appended to the ephemeral folder name"
         required: false
         default: ''
+      backend-dir:
+        description: "Path to backend Dockerfile"
+        required: false
+        default: './app'
+      frontend-dir:
+        description: "Path to frontend Dockerfile"
+        required: false
+        default: './frontend'
 
 jobs:
   build-and-deploy:
@@ -21,3 +29,5 @@ jobs:
         with:
           project: ${{ inputs.project }}
           suffix: ${{ inputs.suffix }}
+          backend-dir: ${{ inputs.backend-dir }}
+          frontend-dir: ${{ inputs.frontend-dir }}

--- a/README.md
+++ b/README.md
@@ -3,3 +3,20 @@
 This repository also contains a reusable Helm chart under `charts/generic-app` for deploying a simple backend and frontend application. You can render manifests or push the chart to an OCI registry.
 
 See `charts/generic-app/README.md` for usage and configuration details.
+
+## Composite actions
+
+The repository provides composite actions for use in your workflows. The
+`build-and-deploy` action checks out the repository to an ephemeral workspace,
+builds backend and frontend Docker images and deploys them via Helm.
+
+```yaml
+- uses: johnhojohn969/setup-ephemeral-action/.github/actions/build-and-deploy@main
+  with:
+    project: my-app
+    backend-dir: ./backend
+    frontend-dir: ./frontend
+```
+
+`backend-dir` and `frontend-dir` default to `./app` and `./frontend`. Override
+them if your repository uses different locations.


### PR DESCRIPTION
## Summary
- add inputs for backend and frontend directories
- document the new inputs in README
- update sample workflow to show how to override default paths

## Testing
- `yamllint .` *(fails: line-length and formatting errors)*

------
https://chatgpt.com/codex/tasks/task_b_687f59606494832daac6c0d640621ba2