### PR TITLE
Add ensure-dirs option

### DIFF
--- a/.github/actions/build-and-deploy/action.yaml
+++ b/.github/actions/build-and-deploy/action.yaml
@@ -16,6 +16,10 @@ inputs:
     description: "Path to frontend Dockerfile"
     required: false
     default: ./frontend
+  ensure-dirs:
+    description: "Create backend and frontend directories if they don't exist"
+    required: false
+    default: "false"
 runs:
   using: composite
   steps:
@@ -23,6 +27,11 @@ runs:
       uses: johnhojohn969/setup-ephemeral-action/.github/actions/checkout@main
       with:
         suffix: ${{ inputs.suffix }}
+    - name: Ensure backend and frontend directories exist
+      if: inputs.ensure-dirs == 'true'
+      shell: bash
+      run: |
+        mkdir -p "${{ inputs.backend-dir }}" "${{ inputs.frontend-dir }}"
     - name: Build and Push Images
       uses: johnhojohn969/setup-ephemeral-action/.github/actions/build-and-push@main
       with:

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -20,6 +20,10 @@ on:
         description: "Path to frontend Dockerfile"
         required: false
         default: './frontend'
+      ensure-dirs:
+        description: "Create backend and frontend directories if missing"
+        required: false
+        default: 'false'
 
 jobs:
   build-and-deploy:
@@ -31,3 +35,4 @@ jobs:
           suffix: ${{ inputs.suffix }}
           backend-dir: ${{ inputs.backend-dir }}
           frontend-dir: ${{ inputs.frontend-dir }}
+          ensure-dirs: ${{ inputs.ensure-dirs }}

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ builds backend and frontend Docker images and deploys them via Helm.
     project: my-app
     backend-dir: ./backend
     frontend-dir: ./frontend
+    ensure-dirs: true
 ```
 
 `backend-dir` and `frontend-dir` default to `./app` and `./frontend`. Override
-them if your repository uses different locations.
+them if your repository uses different locations. Set `ensure-dirs` to `true`
+to create these directories when missing.


### PR DESCRIPTION
## Summary
- allow `build-and-deploy` action to create backend/frontend directories
- document new input in README
- expose input via reusable workflow

## Testing
- `actionlint`
- `yamllint -d '{extends: relaxed, rules: {line-length: {max: 120}}}' .github/**/*.yml`
- `shellcheck push-metrics/push.sh`


------
https://chatgpt.com/codex/tasks/task_b_687fba92fa24832dbf1327586b7b4c57