### PR TITLE
Fix workdir in build actions

### DIFF
--- a/.github/actions/build-and-deploy/action.yaml
+++ b/.github/actions/build-and-deploy/action.yaml
@@ -24,11 +24,13 @@ runs:
       with:
         suffix: ${{ inputs.suffix }}
     - name: Build and Push Images
+      working-directory: ${{ env.WORK_DIR }}
       uses: johnhojohn969/setup-ephemeral-action/.github/actions/build-and-push@main
       with:
         backend-dir: ${{ inputs.backend-dir }}
         frontend-dir: ${{ inputs.frontend-dir }}
     - name: Determine project name
+      working-directory: ${{ env.WORK_DIR }}
       id: vars
       shell: bash
       run: |
@@ -38,6 +40,7 @@ runs:
           echo "name=$(basename ${{ github.repository }})" >> "$GITHUB_OUTPUT"
         fi
     - name: Deploy with Helm
+      working-directory: ${{ env.WORK_DIR }}
       uses: johnhojohn969/setup-ephemeral-action/.github/actions/deploy-helm-generic@main
       with:
         project: ${{ steps.vars.outputs.name }}

--- a/.github/actions/build-and-push/action.yaml
+++ b/.github/actions/build-and-push/action.yaml
@@ -30,6 +30,7 @@ runs:
         echo "name=${repo_name,,}" >> "$GITHUB_OUTPUT"
 
     - name: Build & Push Backend
+      working-directory: ${{ env.WORK_DIR }}
       shell: bash
       run: |
         if [ ! -d "${{ inputs.backend-dir }}" ]; then
@@ -40,6 +41,7 @@ runs:
         docker push ghcr.io/${{ github.actor }}/${{ steps.repo.outputs.name }}-backend:${{ inputs.tag }}
 
     - name: Build & Push Frontend
+      working-directory: ${{ env.WORK_DIR }}
       shell: bash
       run: |
         if [ ! -d "${{ inputs.frontend-dir }}" ]; then

--- a/.github/actions/deploy-helm-generic/action.yaml
+++ b/.github/actions/deploy-helm-generic/action.yaml
@@ -14,6 +14,7 @@ runs:
   using: composite
   steps:
     - name: Helm upgrade/install
+      working-directory: ${{ env.WORK_DIR }}
       shell: bash
       run: |
         helm upgrade --install ${{ inputs.project }} \

--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ builds backend and frontend Docker images and deploys them via Helm.
 - uses: johnhojohn969/setup-ephemeral-action/.github/actions/build-and-deploy@main
   with:
     project: my-app
-    backend-dir: ./backend
+    backend-dir: ./app
     frontend-dir: ./frontend
 ```
 
-`backend-dir` and `frontend-dir` default to `./app` and `./frontend`. Override
-them if your repository uses different locations.
+`backend-dir` and `frontend-dir` default to `./app` and `./frontend`.
+These folders must already exist; the action does not create them automatically.
+Override the paths if your repository uses different locations.


### PR DESCRIPTION
## Summary
- ensure build/deploy steps run from the ephemeral checkout
- drop now unnecessary `ensure-dirs` option
- clarify that build directories must exist

## Testing
- `yamllint -d '{extends: relaxed, rules: {line-length: {max: 120}}}' .github/**/*.yml`
- `shellcheck push-metrics/push.sh`
- ❌ `actionlint` *(failed to download)*

------
https://chatgpt.com/codex/tasks/task_b_687fba92fa24832dbf1327586b7b4c57