### PR TITLE
Improve GHCR login flexibility

### DIFF
--- a/.github/actions/build-and-deploy/action.yaml
+++ b/.github/actions/build-and-deploy/action.yaml
@@ -17,6 +17,10 @@ inputs:
     description: "Path to frontend Dockerfile"
     required: false
     default: ./frontend
+  registry-token:
+    description: "Token used to login to ghcr.io"
+    required: false
+    default: ${{ github.token }}
 runs:
   using: composite
   steps:
@@ -27,7 +31,7 @@ runs:
     - name: Log in to GitHub Container Registry
       shell: bash
       run: |
-        echo "${{ github.token }}" | \
+        echo "${{ inputs.registry-token }}" | \
           docker login ghcr.io -u ${{ github.actor }} --password-stdin
     - name: Extract repo name for image prefix
       id: repo

--- a/.github/actions/build-and-push/action.yaml
+++ b/.github/actions/build-and-push/action.yaml
@@ -14,13 +14,17 @@ inputs:
     description: "Image tag to use (default: latest)"
     required: false
     default: latest
+  registry-token:
+    description: "Token used to login to ghcr.io"
+    required: false
+    default: ${{ github.token }}
 
 runs:
   using: "composite"
   steps:
     - name: Log in to GitHub Container Registry
       shell: bash
-      run: echo "${{ github.token }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      run: echo "${{ inputs.registry-token }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
     - name: Extract repo name for image prefix
       id: repo

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -20,6 +20,14 @@ on:
         description: "Path to frontend Dockerfile"
         required: false
         default: './frontend'
+      registry-token:
+        description: "Token used to login to ghcr.io"
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+  packages: write
 
 jobs:
   build-and-deploy:
@@ -31,3 +39,4 @@ jobs:
           suffix: ${{ inputs.suffix }}
           backend-dir: ${{ inputs.backend-dir }}
           frontend-dir: ${{ inputs.frontend-dir }}
+          registry-token: ${{ inputs.registry-token }}

--- a/README.md
+++ b/README.md
@@ -16,8 +16,12 @@ builds backend and frontend Docker images and deploys them via Helm.
     project: my-app
     backend-dir: ./app
     frontend-dir: ./frontend
+    # optional: token with write access to ghcr.io
+    registry-token: ${{ secrets.GHCR_TOKEN }}
 ```
 
 `backend-dir` and `frontend-dir` default to `./app` and `./frontend`.
 These folders must already exist; the action does not create them automatically.
+If your organization disallows the default `GITHUB_TOKEN` from publishing
+packages, provide a personal access token via `registry-token`.
 Override the paths if your repository uses different locations.


### PR DESCRIPTION
## Summary
- allow custom registry tokens for build-and-push and build-and-deploy actions
- document new option in README
- expose new input in build-and-deploy workflow

## Testing
- `yamllint charts/generic-app/Chart.yaml charts/generic-app/values.yaml charts/generic-app/templates/all.yaml action.yml push-metrics/action.yml .github/actions/build-and-push/action.yaml .github/actions/deploy-helm-generic/action.yaml .github/actions/checkout/action.yaml .github/actions/build-and-deploy/action.yaml .github/workflow-templates/use-ephemeral.yml .github/workflows/build-and-deploy.yml`

------
https://chatgpt.com/codex/tasks/task_b_68804d6a352c832da32f6389d61e365c