### PR TITLE
Add buildx remote composite action

### DIFF
--- a/.github/actions/buildx-remote/action.yaml
+++ b/.github/actions/buildx-remote/action.yaml
@@ -1,0 +1,34 @@
+name: Buildx Remote Build & Push
+description: Build and push a Docker image using Buildx with a remote Git context
+inputs:
+  repository:
+    description: Git repository URL for the build context (e.g. git://github.com/org/repo.git#main)
+    required: true
+  file:
+    description: Path to Dockerfile within the remote repository
+    required: true
+  tag:
+    description: Full image tag including registry
+    required: true
+  registry-token:
+    description: Token used to login to ghcr.io
+    required: false
+    default: ${{ github.token }}
+runs:
+  using: composite
+  steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to GitHub Container Registry
+      shell: bash
+      run: echo "${{ inputs.registry-token }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+    - name: Build & Push image from remote repo
+      shell: bash
+      run: |
+        docker buildx build \
+          --build-context repo=${{ inputs.repository }} \
+          --file ${{ inputs.file }} \
+          --tag ${{ inputs.tag }} \
+          --push .

--- a/README.md
+++ b/README.md
@@ -25,3 +25,17 @@ These folders must already exist; the action does not create them automatically.
 If your organization disallows the default `GITHUB_TOKEN` from publishing
 packages, provide a personal access token via `registry-token`.
 Override the paths if your repository uses different locations.
+
+### Buildx Remote Build Action
+
+Use the `buildx-remote` action to build and push a Docker image using a remote Git repository as the build context.
+
+```yaml
+- uses: johnhojohn969/setup-ephemeral-action/.github/actions/buildx-remote@main
+  with:
+    repository: git://github.com/johnhojohn969/your-app.git#main
+    file: repo/Dockerfile
+    tag: ghcr.io/${{ github.actor }}/your-app:latest
+```
+
+Provide `registry-token` if the default `GITHUB_TOKEN` cannot push to GHCR.


### PR DESCRIPTION
## Summary
- add `buildx-remote` composite action for building from remote git context
- document new action in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68806f476e18832d9d8450b0b95a3106