### PR TITLE
Add deploy-helm action and workflow template

### DIFF
--- a/.github/actions/deploy-helm/action.yaml
+++ b/.github/actions/deploy-helm/action.yaml
@@ -1,0 +1,41 @@
+name: Deploy Helm Chart
+description: "Deploy a Helm chart using helm upgrade --install"
+inputs:
+  release:
+    description: "Helm release name"
+    required: true
+  chart:
+    description: "Chart reference or path"
+    required: true
+  values:
+    description: "Path to values.yaml"
+    required: false
+    default: ''
+  namespace:
+    description: "Kubernetes namespace"
+    required: false
+    default: ''
+  extra-args:
+    description: "Additional arguments for helm"
+    required: false
+    default: ''
+runs:
+  using: composite
+  steps:
+    - name: Helm upgrade/install
+      working-directory: ${{ env.WORK_DIR }}
+      shell: bash
+      run: |
+        set -e
+        cmd=(helm upgrade --install "${{ inputs.release }}" "${{ inputs.chart }}")
+        if [ -n "${{ inputs.values }}" ]; then
+          cmd+=( -f "${{ inputs.values }}" )
+        fi
+        if [ -n "${{ inputs.namespace }}" ]; then
+          cmd+=( --namespace "${{ inputs.namespace }}" --create-namespace )
+        fi
+        if [ -n "${{ inputs.extra-args }}" ]; then
+          cmd+=( ${{ inputs.extra-args }} )
+        fi
+        echo "Running: ${cmd[@]}"
+        "${cmd[@]}"

--- a/.github/workflow-templates/buildx-and-deploy.yml
+++ b/.github/workflow-templates/buildx-and-deploy.yml
@@ -1,0 +1,42 @@
+# Template building a remote repository with Buildx and deploying via Helm
+name: Buildx Remote and Deploy Helm
+on:
+  workflow_dispatch:
+    inputs:
+      release:
+        description: Helm release name
+        required: true
+      repository:
+        description: Git repository URL for Buildx
+        required: true
+      dockerfile:
+        description: Path to Dockerfile in the remote repo
+        required: true
+      image-tag:
+        description: Full image tag
+        required: true
+      values:
+        description: Path to values file for Helm
+        required: true
+      chart:
+        description: Helm chart reference
+        required: true
+      namespace:
+        description: Kubernetes namespace
+        required: true
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: johnhojohn969/setup-ephemeral-action/.github/actions/checkout@main
+      - uses: johnhojohn969/setup-ephemeral-action/.github/actions/buildx-remote@main
+        with:
+          repository: ${{ inputs.repository }}
+          file: ${{ inputs.dockerfile }}
+          tag: ${{ inputs.image-tag }}
+      - uses: johnhojohn969/setup-ephemeral-action/.github/actions/deploy-helm@main
+        with:
+          release: ${{ inputs.release }}
+          chart: ${{ inputs.chart }}
+          values: ${{ inputs.values }}
+          namespace: ${{ inputs.namespace }}

--- a/README.md
+++ b/README.md
@@ -39,3 +39,18 @@ Use the `buildx-remote` action to build and push a Docker image using a remote G
 ```
 
 Provide `registry-token` if the default `GITHUB_TOKEN` cannot push to GHCR.
+
+### Deploy Helm Chart
+
+The `deploy-helm` action runs a simple `helm upgrade --install` command. It accepts the release name, chart reference and optional values file and namespace.
+
+```yaml
+- uses: johnhojohn969/setup-ephemeral-action/.github/actions/deploy-helm@main
+  with:
+    release: my-app
+    chart: oci://ghcr.io/johnhojohn969/generic-app
+    values: ./projects/my-app/values.yaml
+    namespace: my-app
+```
+
+See `.github/workflow-templates/buildx-and-deploy.yml` for a full example combining `buildx-remote` and this action.


### PR DESCRIPTION
## Summary
- add `deploy-helm` composite action for generic helm upgrades
- provide template that uses `buildx-remote` and the new helm action
- document how to use the new action

## Testing
- `helm lint charts/generic-app` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_688071d439ec832da422ad1cbf09fb85