### PR TITLE
Add simplified deploy-helm action

### DIFF
--- a/.github/actions/deploy-helm/action.yaml
+++ b/.github/actions/deploy-helm/action.yaml
@@ -1,0 +1,28 @@
+name: Deploy Helm Chart
+description: Install or upgrade a project using the generic Helm chart.
+inputs:
+  project:
+    description: "Project folder under ./projects containing values.yaml"
+    required: false
+    default: ''
+runs:
+  using: composite
+  steps:
+    - name: Determine project name
+      id: vars
+      shell: bash
+      run: |
+        if [ -n "${{ inputs.project }}" ]; then
+          echo "name=${{ inputs.project }}" >> "$GITHUB_OUTPUT"
+        else
+          echo "name=$(basename ${{ github.repository }})" >> "$GITHUB_OUTPUT"
+        fi
+    - name: Deploy with Helm
+      working-directory: ${{ github.workspace }}
+      shell: bash
+      run: |
+        helm upgrade --install ${{ steps.vars.outputs.name }} \
+          oci://ghcr.io/johnhojohn969/generic-app \
+          -f ./projects/${{ steps.vars.outputs.name }}/values.yaml \
+          --namespace ${{ steps.vars.outputs.name }} \
+          --create-namespace

--- a/.github/workflow-templates/buildx-and-deploy.yml
+++ b/.github/workflow-templates/buildx-and-deploy.yml
@@ -1,0 +1,29 @@
+# Template building a remote repository with Buildx and deploying via Helm
+name: Buildx Remote and Deploy Helm
+on:
+  workflow_dispatch:
+    inputs:
+      project:
+        description: Name of the project to deploy
+        required: true
+      repository:
+        description: Git repository URL for Buildx
+        required: true
+      dockerfile:
+        description: Path to Dockerfile in the remote repo
+        required: true
+      image-tag:
+        description: Full image tag
+        required: true
+jobs:
+  build-deploy:
+    runs-on: self-hosted
+    steps:
+      - uses: johnhojohn969/setup-ephemeral-action/.github/actions/buildx-remote@main
+        with:
+          repository: ${{ inputs.repository }}
+          file: ${{ inputs.dockerfile }}
+          tag: ${{ inputs.image-tag }}
+      - uses: johnhojohn969/setup-ephemeral-action/.github/actions/deploy-helm@main
+        with:
+          project: ${{ inputs.project }}

--- a/README.md
+++ b/README.md
@@ -39,3 +39,25 @@ Use the `buildx-remote` action to build and push a Docker image using a remote G
 ```
 
 Provide `registry-token` if the default `GITHUB_TOKEN` cannot push to GHCR.
+
+### Deploy Helm Chart
+
+Use `deploy-helm` when you only need to install or upgrade one of the provided projects using the generic chart. The repository should already be checked out before calling the action.
+
+```yaml
+- uses: actions/checkout@v3
+- uses: johnhojohn969/setup-ephemeral-action/.github/actions/deploy-helm@main
+  with:
+    project: my-app
+```
+
+The action runs:
+
+```bash
+helm upgrade --install <project> \
+  oci://ghcr.io/johnhojohn969/generic-app \
+  -f ./projects/<project>/values.yaml \
+  --namespace <project> --create-namespace
+```
+
+See `.github/workflow-templates/buildx-and-deploy.yml` for a workflow using this action together with `buildx-remote`.


### PR DESCRIPTION
## Summary
- rewrite `deploy-helm` action to mirror the deploy step from `build-and-deploy`
- adjust the workflow template to use the new action
- update README documentation
- use self-hosted runner and remove checkout in `buildx-and-deploy` template

## Testing
- `helm lint charts/generic-app`


------
https://chatgpt.com/codex/tasks/task_b_688071d439ec832da422ad1cbf09fb85