### PR TITLE
Add GIT_PAT usage for GHCR

### DIFF
--- a/.github/actions/build-and-deploy/action.yaml
+++ b/.github/actions/build-and-deploy/action.yaml
@@ -31,8 +31,9 @@ runs:
     - name: Log in to GitHub Container Registry
       shell: bash
       run: |
+        REGISTRY_USER="${{ github.triggering_actor || github.actor }}"
         echo "${{ inputs.registry-token }}" | \
-          docker login ghcr.io -u ${{ github.actor }} --password-stdin
+          docker login ghcr.io -u "$REGISTRY_USER" --password-stdin
     - name: Extract repo name for image prefix
       id: repo
       shell: bash

--- a/.github/actions/build-and-push/action.yaml
+++ b/.github/actions/build-and-push/action.yaml
@@ -24,7 +24,9 @@ runs:
   steps:
     - name: Log in to GitHub Container Registry
       shell: bash
-      run: echo "${{ inputs.registry-token }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      run: |
+        REGISTRY_USER="${{ github.triggering_actor || github.actor }}"
+        echo "${{ inputs.registry-token }}" | docker login ghcr.io -u "$REGISTRY_USER" --password-stdin
 
     - name: Extract repo name for image prefix
       id: repo

--- a/.github/actions/buildx-remote/action.yaml
+++ b/.github/actions/buildx-remote/action.yaml
@@ -22,7 +22,9 @@ runs:
 
     - name: Log in to GitHub Container Registry
       shell: bash
-      run: echo "${{ inputs.registry-token }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      run: |
+        REGISTRY_USER="${{ github.triggering_actor || github.actor }}"
+        echo "${{ inputs.registry-token }}" | docker login ghcr.io -u "$REGISTRY_USER" --password-stdin
 
     - name: Build & Push image from remote repo
       shell: bash

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -21,7 +21,7 @@ on:
         required: false
         default: './frontend'
       registry-token:
-        description: "Token used to login to ghcr.io"
+        description: "Token used to login to ghcr.io (defaults to GIT_PAT secret)"
         required: false
         default: ''
 
@@ -39,4 +39,4 @@ jobs:
           suffix: ${{ inputs.suffix }}
           backend-dir: ${{ inputs.backend-dir }}
           frontend-dir: ${{ inputs.frontend-dir }}
-          registry-token: ${{ inputs.registry-token }}
+          registry-token: ${{ inputs.registry-token || secrets.GIT_PAT }}

--- a/README.md
+++ b/README.md
@@ -16,9 +16,12 @@ builds backend and frontend Docker images and deploys them via Helm.
     project: my-app
     backend-dir: ./app
     frontend-dir: ./frontend
-    # optional: token with write access to ghcr.io
-    registry-token: ${{ secrets.GHCR_TOKEN }}
+    # optional: token with write access to ghcr.io (defaults to secrets.GIT_PAT)
+    registry-token: ${{ secrets.GIT_PAT }}
 ```
+
+The action authenticates to GHCR using the workflow trigger's username
+via `github.triggering_actor` (falling back to `github.actor`).
 
 `backend-dir` and `frontend-dir` default to `./app` and `./frontend`.
 These folders must already exist; the action does not create them automatically.


### PR DESCRIPTION
## Summary
- set REGISTRY_USER in build actions so the login uses the workflow trigger's username
- default `build-and-deploy` workflow to use `secrets.GIT_PAT`
- document GIT_PAT usage in README

## Testing
- `yamllint .github/actions/build-and-deploy/action.yaml`
- `yamllint .github/actions/buildx-remote/action.yaml` *(fails: line too long)*
- `yamllint .github/actions/build-and-push/action.yaml`


------
https://chatgpt.com/codex/tasks/task_b_688087184f98832da8c0a6f470265b9c