### PR TITLE
Refactor buildx workflow

### DIFF
--- a/.github/workflow-templates/buildx-and-deploy.yml
+++ b/.github/workflow-templates/buildx-and-deploy.yml
@@ -1,29 +1,67 @@
-# Template building a remote repository with Buildx and deploying via Helm
-name: Buildx Remote and Deploy Helm
+# Template building local source folders with Buildx and deploying via Helm
+name: Buildx and Deploy
 on:
   workflow_dispatch:
     inputs:
-      project:
-        description: Name of the project to deploy
+      sources:
+        description: |
+          Source folders containing Dockerfile and values.yml separated by '|'
         required: true
-      repository:
-        description: Git repository URL for Buildx
-        required: true
-      dockerfile:
-        description: Path to Dockerfile in the remote repo
-        required: true
-      image-tag:
-        description: Full image tag
-        required: true
+      suffix:
+        description: Optional suffix appended to the ephemeral folder name
+        required: false
+        default: ''
+      chart:
+        description: Helm chart reference
+        required: false
+        default: oci://ghcr.io/johnhojohn969/generic-app
+      registry-token:
+        description: Token used to login to ghcr.io (defaults to GIT_PAT secret)
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+  packages: write
 jobs:
   build-deploy:
     runs-on: self-hosted
     steps:
-      - uses: johnhojohn969/setup-ephemeral-action/.github/actions/buildx-remote@main
+      - uses: johnhojohn969/setup-ephemeral-action@main
         with:
-          repository: ${{ inputs.repository }}
-          file: ${{ inputs.dockerfile }}
-          tag: ${{ inputs.image-tag }}
-      - uses: johnhojohn969/setup-ephemeral-action/.github/actions/deploy-helm@main
-        with:
-          project: ${{ inputs.project }}
+          suffix: ${{ inputs.suffix }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to GitHub Container Registry
+        shell: bash
+        run: |
+          REGISTRY_USER="${{ github.triggering_actor || github.actor }}"
+          echo "${{ inputs.registry-token || secrets.GIT_PAT }}" | \
+            docker login ghcr.io -u "$REGISTRY_USER" --password-stdin
+      - name: Extract repo name for image prefix
+        id: repo
+        shell: bash
+        run: |
+          repo_name=$(basename "${{ github.repository }}")
+          echo "name=${repo_name,,}" >> "$GITHUB_OUTPUT"
+      - name: Build and Deploy
+        working-directory: ${{ env.WORK_DIR }}
+        shell: bash
+        run: |
+          IFS='|' read -ra DIRS <<< "${{ inputs.sources }}"
+          for dir in "${DIRS[@]}"; do
+            if [ ! -d "$dir" ]; then
+              echo "Source directory '$dir' not found" >&2
+              exit 1
+            fi
+            name=$(basename "$dir")
+            image="ghcr.io/${{ github.repository_owner }}/${{ steps.repo.outputs.name }}-$name:latest"
+            docker buildx build -t "$image" --push "$dir"
+            if [ ! -f "$dir/values.yml" ]; then
+              echo "Values file '$dir/values.yml' not found" >&2
+              exit 1
+            fi
+            helm upgrade --install "$name" "${{ inputs.chart }}" \
+              -f "$dir/values.yml" \
+              --namespace "$name" --create-namespace
+          done


### PR DESCRIPTION
## Summary
- adjust buildx-and-deploy workflow to use the base action instead of the checkout composite

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_68808bc76cc0832d9979d11178319047